### PR TITLE
Update organ-mapping.json

### DIFF
--- a/containers/azimuth/context/organ-mapping.json
+++ b/containers/azimuth/context/organ-mapping.json
@@ -7,8 +7,7 @@
   "UBERON:0000948": "heartref",
   "UBERON:0000955": "humancortexref",
   "UBERON:0001264": "pancreasref",
-  "UBERON:0000029": "tonsilref",
-  "UBERON:0004537": "pbmcref",
+  "UBERON:0002373": "tonsilref",
   "UBERON:0000178": "pbmcref",
   "UBERON:0002371": "bonemarrowref",
   "UBERON:0001013": "adiposeref"


### PR DESCRIPTION
1) Change tonsilref from uberon id UBERON:0000029 for lymph node to palatine tonsil UBERON:0002373 
2) Removed "UBERON:0004537": "pbmcref", because this is blood vasculature and does not have the same cell types as blood; PBMC (peripheral blood mononuclear cells) is a white blood cell fraction of whole blood.